### PR TITLE
Split LocalPlay / Slice component

### DIFF
--- a/shared/components/LocalPlay.js
+++ b/shared/components/LocalPlay.js
@@ -4,7 +4,6 @@ const { Component, wire } = require('hypermorphic');
 
 const Volume = require('./Volume');
 const Duration = require('./Duration');
-const Slice = require('./Slice');
 const getDisplayName = require('../helpers/getDisplayName');
 const getDownloadName = require('../helpers/getDownloadName');
 
@@ -63,9 +62,10 @@ function Buttons(
 }
 
 class LocalPlay extends Component {
-  constructor(file) {
+  constructor({ file, onMediaLoaded }) {
     super();
     this.file = file;
+    this.onMediaLoaded = onMediaLoaded;
     this.handlePlay = this.handlePlay.bind(this);
     this.handlePause = this.handlePause.bind(this);
     this.handleLoop = this.handleLoop.bind(this);
@@ -77,11 +77,13 @@ class LocalPlay extends Component {
     this.audio = new Audio(this.objectURL);
     this.interval = setInterval(() => {
       if (isMediaLoaded(this.audio)) {
+        clearInterval(this.interval);
         this.volume = new Volume(this.audio);
         this.duration = new Duration(this.audio);
-        this.slice = new Slice(this.audio, this.file);
+        if (typeof this.onMediaLoaded === 'function') {
+          this.onMediaLoaded(this.audio);
+        }
         URL.revokeObjectURL(this.objectURL);
-        clearInterval(this.interval);
       }
       this.render();
     }, 100);
@@ -151,7 +153,6 @@ class LocalPlay extends Component {
                   this.handlePause,
                   this.handleDownload
                 ),
-                this.slice,
               ]
             : ''
         }

--- a/shared/components/Shared.js
+++ b/shared/components/Shared.js
@@ -66,12 +66,13 @@ class Shared extends Component {
 
   render() {
     const state = this.state;
+    const file = state.file;
 
     return this.html`
       <div onconnected=${this}>
         ${[state.error ? ErrorMessage() : '']}
         ${[state.loading ? Loading() : '']}
-        ${[this.state.file ? new LocalPlay(this.state.file) : '']}
+        ${[file ? new LocalPlay({ file }) : '']}
       </div>
     `;
   }

--- a/shared/helpers/getDownloadName.js
+++ b/shared/helpers/getDownloadName.js
@@ -1,5 +1,5 @@
 module.exports = function getDisplayName(displayName, extension) {
-  return displayName.split(`${extension}`).pop()
+  return displayName.split(extension).pop()
     ? `${displayName}.${extension}`
     : displayName;
 };


### PR DESCRIPTION
- `LocalPlay` triggers an optional callback once media is ready
- `LocalPlay` no longer renders `Slice` component
- Simplify `Upload` and `Link` components
- `Shared` component now only renders `LocalPlay`, not `Slice` component unnecessarily
- `Link` component now auto-submits audio extract if an URL initial value is provided
