### PR TITLE
 Draw the waveform from 100kb decoded chunks

### DIFF
--- a/shared/helpers/ArrayBuffer.concat.js
+++ b/shared/helpers/ArrayBuffer.concat.js
@@ -1,0 +1,17 @@
+/**
+ * Creates a new Uint8Array based on two different ArrayBuffers
+ * https://gist.github.com/72lions/4528834
+ *
+ * @private
+ * @param {ArrayBuffer} buffer1 The first buffer.
+ * @param {ArrayBuffer} buffer2 The second buffer.
+ * @return {ArrayBuffer} The new ArrayBuffer created out of the two.
+ */
+function concatArrayBuffer(buffer1, buffer2) {
+  const tmp = new Uint8Array(buffer1.byteLength + buffer2.byteLength);
+  tmp.set(new Uint8Array(buffer1), 0);
+  tmp.set(new Uint8Array(buffer2), buffer1.byteLength);
+  return tmp.buffer;
+}
+
+module.exports = concatArrayBuffer;

--- a/shared/helpers/AudioBuffer.concat.js
+++ b/shared/helpers/AudioBuffer.concat.js
@@ -1,0 +1,26 @@
+/**
+ * Appends two AudioBuffers into a new one.
+ *
+ * @param {AudioContext} context audio context to create new buffer from.
+ * @param {AudioBuffer} buffer1 The first buffer.
+ * @param {AudioBuffer} buffer2 The second buffer.
+ */
+function concatAudioBuffer(context, buffer1, buffer2) {
+  const numberOfChannels = Math.min(
+    buffer1.numberOfChannels,
+    buffer2.numberOfChannels
+  );
+  const tmp = context.createBuffer(
+    numberOfChannels,
+    buffer1.length + buffer2.length,
+    buffer1.sampleRate
+  );
+  for (let i = 0; i < numberOfChannels; i++) {
+    const channel = tmp.getChannelData(i);
+    channel.set(buffer1.getChannelData(i), 0);
+    channel.set(buffer2.getChannelData(i), buffer1.length);
+  }
+  return tmp;
+}
+
+module.exports = concatAudioBuffer;


### PR DESCRIPTION
Audio data can be decoded from each chunk using `AudioContext.prototype.decodeAudioData(chunkArrayBuffer)`

- progressively decode file audio data and draw waveform
- handle larger files
- drastically reduce the memory usage of audio data decoding
