### PR TITLE
Slice by clicking on the WaveForm

### DIFF
--- a/assets/styles/components/WaveForm.scss
+++ b/assets/styles/components/WaveForm.scss
@@ -1,7 +1,15 @@
 @import '../abstracts/variables.scss';
 
 #WaveForm {
-  cursor: none;
   padding: $spacing 0;
+  margin: $spacing 0;
   background-color: $color-blue-darker;
+
+  &.can-select {
+    cursor: none;
+  }
+
+  &.will-reset {
+    cursor: not-allowed;
+  }
 }

--- a/shared/components/Link.js
+++ b/shared/components/Link.js
@@ -4,7 +4,6 @@ const { Component, wire } = require('hypermorphic');
 
 const LocalPlay = require('./LocalPlay');
 const Slice = require('./Slice');
-const WaveForm = require('./WaveForm');
 const getDisplayName = require('../helpers/getDisplayName');
 
 const linkPath = '/api/link';
@@ -130,7 +129,6 @@ class Link extends Component {
 
   onMediaLoaded(audio) {
     this.slice = new Slice(audio, this.state.file);
-    this.waveForm = new WaveForm(audio, this.state.file);
     this.render();
   }
 
@@ -175,7 +173,6 @@ class Link extends Component {
           </button>
         </p>
         ${[this.localPlay || '']}
-        ${[this.waveForm || '']}
         ${[this.slice || '']}
       </form>
     `;

--- a/shared/components/Upload.js
+++ b/shared/components/Upload.js
@@ -5,7 +5,6 @@ const { encode } = require('punycode');
 
 const LocalPlay = require('./LocalPlay');
 const Slice = require('./Slice');
-const WaveForm = require('./WaveForm');
 const getDisplayName = require('../helpers/getDisplayName');
 
 const requiredFileTypes = ['audio/mpeg', 'audio/mp3'];
@@ -123,7 +122,6 @@ class Upload extends Component {
 
   onMediaLoaded(audio) {
     this.slice = new Slice(audio, this.state.file);
-    this.waveForm = new WaveForm(audio, this.state.file);
     this.render();
   }
 
@@ -163,7 +161,6 @@ class Upload extends Component {
           />
         </fieldset>
         ${[this.localPlay || '']}
-        ${[this.waveForm || '']}
         ${[this.slice || '']}
       </form>
     `;


### PR DESCRIPTION
- Remove form/input-based slice boundaries selection
- a first click on the WaveForm sets the start boundary
- a second click sets the end boundary
- a third click resets the slice and its boundaries
- save and restore waveform canvas image data snapshots

![screen shot 2019-02-10 at 12 04 45](https://user-images.githubusercontent.com/2394128/52532980-32c41400-2d2d-11e9-9381-44ea5b05df8f.png)
