### PR TITLE
Allow unsharing a shared slice

### DIFF
--- a/database/create-table-slices.sql
+++ b/database/create-table-slices.sql
@@ -4,6 +4,7 @@
 
 CREATE TABLE slices (
     id character(64) NOT NULL,
+    owner character varying(10) NOT NULL,    
     json json NOT NULL
 );
 

--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 const path = require('path');
-const { rename, createReadStream } = require('fs');
+const { unlink, rename, createReadStream } = require('fs');
 const { createHash } = require('crypto');
 const express = require('express');
 const favicon = require('serve-favicon');
@@ -31,6 +31,12 @@ const finalDir = env === 'development' ? '/tmp' : '/home/hosting-user/uploads';
 function renameAsync(oldPath, newPath) {
   return new Promise((resolve, reject) => {
     rename(oldPath, newPath, err => (err ? reject(err) : resolve()));
+  });
+}
+
+function unlinkAsync(path) {
+  return new Promise((resolve, reject) => {
+    unlink(path, err => (err ? reject(err) : resolve()));
   });
 }
 
@@ -70,6 +76,9 @@ app.post('/api/share', function(req, res) {
       res.end(JSON.stringify({ status: 'error', message: 'Missing file' }));
       return;
     }
+
+    const owner = req.get('X-Browser-Id') || 'anonymous';
+
     // {
     //   fieldName: 'file',
     //   originalFilename: 'foobarbaz.mp3',
@@ -100,10 +109,10 @@ app.post('/api/share', function(req, res) {
           path: destination,
           name: file.originalFilename,
         });
-        await client.query('INSERT INTO slices(id, json) VALUES($1, $2)', [
-          id,
-          json,
-        ]);
+        await client.query(
+          'INSERT INTO slices(id, owner, json) VALUES($1, $2, $3)',
+          [id, owner, json]
+        );
         console.info('DID insert', id);
         await renameAsync(file.path, destination);
         console.info('Moved file to final location', destination);
@@ -289,7 +298,7 @@ app.get('/api/slice/:id', async function(req, res) {
   let result;
   try {
     console.info('Retrieving slice json', id);
-    result = await query('SELECT json FROM slices WHERE id LIKE $1', [
+    result = await query('SELECT owner, json FROM slices WHERE id LIKE $1', [
       `${id}%`,
     ]);
   } catch (err) {
@@ -312,6 +321,7 @@ app.get('/api/slice/:id', async function(req, res) {
     return;
   }
 
+  const isOwner = row.owner === req.get('X-Browser-Id');
   const { path, name } = row.json;
 
   console.info('Is file readable?', path);
@@ -327,10 +337,103 @@ app.get('/api/slice/:id', async function(req, res) {
   const headers = {
     'content-disposition': `attachment; filename="${encode(name)}"`,
     'content-type': 'audio/mp3',
+    'X-Owner': isOwner ? 1 : 0,
   };
+
   res.writeHead(200, headers);
   console.info('Streaming slice back to client', name);
   fileStream.pipe(res);
+});
+
+app.delete('/api/slice/:id', async function(req, res) {
+  const id = req.params.id;
+
+  if (!id) {
+    res.sendStatus(422);
+    res.end();
+    return;
+  }
+
+  const owner = req.get('X-Browser-Id') || '';
+  if (!owner) {
+    res.sendStatus(401);
+    res.end();
+    return;
+  }
+
+  let result;
+  try {
+    console.info('Retrieving slice json', id);
+    result = await query('SELECT owner, json FROM slices WHERE id LIKE $1', [
+      `${id}%`,
+    ]);
+  } catch (err) {
+    console.error(err);
+    res.sendStatus(500);
+    res.end();
+    return;
+  }
+
+  if (result.rows.length > 1) {
+    res.sendStatus(409);
+    res.end();
+    return;
+  }
+
+  const row = result.rows[0];
+  if (!row) {
+    res.sendStatus(404);
+    res.end();
+    return;
+  }
+
+  const isOwner = row.owner === req.get('X-Browser-Id');
+  if (!isOwner || req.get('X-Browser-Id') === 'anonymous') {
+    res.sendStatus(403);
+    res.end();
+    return;
+  }
+
+  const { path } = row.json;
+  console.info('Is file readable?', path);
+  const readOK = await isFileReadable(path);
+  if (!readOK) {
+    res.sendStatus(404);
+    res.end();
+    return;
+  }
+
+  try {
+    const client = await getClient();
+    try {
+      await client.query('BEGIN');
+      console.info('BEGIN transaction', id);
+      await client.query('DELETE FROM slices WHERE id = $1 AND owner = $2', [
+        id,
+        owner,
+      ]);
+      console.info('DID delete', id);
+      await unlinkAsync(path);
+      console.info('Removed file', path);
+      await client.query('COMMIT');
+      console.info('COMMIT transaction', id);
+    } catch (err) {
+      await client.query('ROLLBACK');
+      console.info('ROLLBACK transaction', id);
+      throw err;
+    } finally {
+      console.info('Releasing connection', id);
+      client.release();
+    }
+  } catch (err) {
+    console.error(err);
+    res.writeHead(500);
+    res.end();
+    return;
+  }
+
+  res.writeHead(204);
+  res.end();
 });
 
 app.get('/link', function(req, res) {

--- a/shared/components/Source/SharedDisclaimer.js
+++ b/shared/components/Source/SharedDisclaimer.js
@@ -1,0 +1,34 @@
+const { wire } = require('hypermorphic');
+
+/* eslint-disable indent */
+
+function SharedDisclaimer({ id, owner }) {
+  const url = `${window.location.origin}/shared/${id.slice(0, 10)}`;
+
+  return wire()`
+    <h3>
+      This slice was saved on the server
+    </h3>
+    <p>
+      It can be shared using the <strong>current URL</strong>.
+      <br />
+      <label for="share" class="flex flex-justify-content-between">
+        Sharing link for this slice
+      </label>
+      <input id="share" class="full-width" type="text" value=${url} />      
+    </p>
+    ${
+      owner
+        ? wire()`
+          <p>
+            As the <strong>creator</strong> of this slice, <strong>only you</strong> can <strong>unshare</strong> it.
+            <br />
+            If you wish to keep access to this slice for <strong>yourself</strong>, you can <strong>download it</strong> or <strong>save it in this browser</strong>.
+          </p>
+          `
+        : ''
+    }
+  `;
+}
+
+module.exports = SharedDisclaimer;

--- a/shared/components/Source/SourceActions.js
+++ b/shared/components/Source/SourceActions.js
@@ -11,10 +11,12 @@ function SourceActions({
   type,
   saved,
   shared,
+  owner,
   disabled,
   mediaIsLoaded,
   handleSave,
   handleShare,
+  handleUnshare,
   handleDelete,
   handleDownload,
 }) {
@@ -40,18 +42,25 @@ function SourceActions({
       </button>
     `;
 
-  const shareButton =
-    shareAllowedTypes.indexOf(type) > -1
-      ? wire()`
+  const sharedOwner = shared && owner;
+  const shareAllowed =
+    shareAllowedTypes.indexOf(type) > -1 && (!shared || sharedOwner);
+  let shareButton = '';
+  if (shareAllowed) {
+    const className = `button--xsmall button--withicon ${
+      sharedOwner ? 'button--danger' : ''
+    }`;
+    const icon = sharedOwner ? Cross('sand') : Share();
+    shareButton = wire()`
       <button
-        disabled=${disabled || shared}
-        onClick=${handleShare}
-        class="button--xsmall button--withicon"
+        disabled=${disabled}
+        onClick=${sharedOwner ? handleUnshare : handleShare}
+        class="${className}"
       >
-        ${Share()} <span>Share</span>
+        ${icon} <span>${sharedOwner ? 'Unshare' : 'Share'}</span>
       </button>
-    `
-      : '';
+    `;
+  }
 
   return wire()`
     <div class="button-container padding-y-xsmall flex flex-grow1 flex-justify-content-end">

--- a/shared/components/UnsharedAlert.js
+++ b/shared/components/UnsharedAlert.js
@@ -1,0 +1,19 @@
+const { wire } = require('hypermorphic');
+
+/* eslint-disable indent */
+function UnsharedAlert() {
+  return wire()`
+    <h3>
+      This slice is no longer saved on the server.
+    </h3>
+    <p>
+      Sharing the <strong>current URL</strong> <strong>no longer works</strong>.
+      <br />
+      If you wish to keep access to this slice for <strong>yourself</strong>, you can <strong>download it</strong> or <strong>save it in this browser</strong>.
+      <br />
+      If unsharing this slice was a <strong>mistake</strong>, you can <strong>share</strong> it again.      
+    </p>
+  `;
+}
+
+module.exports = UnsharedAlert;

--- a/shared/helpers/browserId.js
+++ b/shared/helpers/browserId.js
@@ -1,0 +1,20 @@
+function dec2hex(dec) {
+  return ('0' + dec.toString(16)).substr(-2);
+}
+
+function generateId() {
+  const arr = new Uint8Array(5);
+  window.crypto.getRandomValues(arr);
+  return Array.from(arr, dec2hex).join('');
+}
+
+function ensureBrowserId() {
+  let id = window.localStorage.getItem('browser');
+  if (!id) {
+    id = generateId();
+    window.localStorage.setItem('browser', id);
+  }
+  return id;
+}
+
+module.exports = { ensureBrowserId };

--- a/shared/helpers/fetchSlice.js
+++ b/shared/helpers/fetchSlice.js
@@ -1,0 +1,47 @@
+const { ensureBrowserId } = require('./browserId');
+
+const SLICE_PATH = '/api/slice';
+
+async function fetchSlice(id) {
+  let browserId = 'anonymous';
+  try {
+    browserId = ensureBrowserId();
+  } catch (err) {
+    console.error({ err });
+    /* pass */
+  }
+
+  const url = `${SLICE_PATH}/${id}`;
+
+  const fetchPromise = fetch(url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'audio/mpeg; charset=utf-8',
+      'X-Browser-Id': browserId,
+    },
+  });
+
+  try {
+    const response = await fetchPromise;
+    if (response.status !== 200) {
+      throw response;
+    }
+
+    const blob = await response.blob();
+    const owner = response.headers.get('X-Owner') === '1';
+    const filename = response.headers
+      .get('content-disposition')
+      .match(/filename="(.+)"/)[1];
+    const file = new File([blob], filename);
+
+    return {
+      file,
+      owner,
+    };
+  } catch (err) {
+    console.error({ err });
+    throw err;
+  }
+}
+
+module.exports = fetchSlice;

--- a/shared/helpers/unshareSlice.js
+++ b/shared/helpers/unshareSlice.js
@@ -1,8 +1,8 @@
 const { ensureBrowserId } = require('./browserId');
 
-const SHARE_PATH = '/api/share';
+const SLICE_PATH = '/api/slice';
 
-async function shareSlice(file) {
+async function unshareSlice(id) {
   let browserId = 'anonymous';
   try {
     browserId = ensureBrowserId();
@@ -11,13 +11,10 @@ async function shareSlice(file) {
     /* pass */
   }
 
-  const filename = file.name;
-  const formData = new FormData();
-  formData.append('file', file, filename);
+  const url = `${SLICE_PATH}/${id}`;
 
-  const promise = fetch(SHARE_PATH, {
-    method: 'POST',
-    body: formData,
+  const promise = fetch(url, {
+    method: 'DELETE',
     headers: {
       'X-Browser-Id': browserId,
     },
@@ -26,18 +23,15 @@ async function shareSlice(file) {
   try {
     const response = await promise;
 
-    if (response.status !== 201) {
+    if (response.status !== 204) {
       const err = new Error('Server Error');
       err.response = response;
       throw err;
     }
-
-    const data = await response.json();
-    return data.id;
   } catch (err) {
     console.error({ err });
     throw err;
   }
 }
 
-module.exports = shareSlice;
+module.exports = unshareSlice;


### PR DESCRIPTION
- Add 'owner' varchar(10) column to slices table
- Generate a random 10chars hex string serving as a browser id, store it
in localstorage upon first use and retrieve it when necessary
- Forward the browserId in create/fetch/delete slice API calls
- Forward whether request browser id matches fetched slice owner in
response
- Allow to unshare a slice (delete from db and file on server) if owner + error handling (401, 403, 404, 409, 422, 500)
- Add some usage tips